### PR TITLE
fixed some unnecessary redefinitions

### DIFF
--- a/include/h264-ctrls.h
+++ b/include/h264-ctrls.h
@@ -71,26 +71,6 @@ enum v4l2_mpeg_video_h264_start_code {
 #define V4L2_H264_SPS_FLAG_MB_ADAPTIVE_FRAME_FIELD		0x20
 #define V4L2_H264_SPS_FLAG_DIRECT_8X8_INFERENCE			0x40
 
-struct v4l2_ctrl_h264_sps {
-	__u8 profile_idc;
-	__u8 constraint_set_flags;
-	__u8 level_idc;
-	__u8 seq_parameter_set_id;
-	__u8 chroma_format_idc;
-	__u8 bit_depth_luma_minus8;
-	__u8 bit_depth_chroma_minus8;
-	__u8 log2_max_frame_num_minus4;
-	__u8 pic_order_cnt_type;
-	__u8 log2_max_pic_order_cnt_lsb_minus4;
-	__u8 max_num_ref_frames;
-	__u8 num_ref_frames_in_pic_order_cnt_cycle;
-	__s32 offset_for_ref_frame[255];
-	__s32 offset_for_non_ref_pic;
-	__s32 offset_for_top_to_bottom_field;
-	__u16 pic_width_in_mbs_minus1;
-	__u16 pic_height_in_map_units_minus1;
-	__u32 flags;
-};
 
 #define V4L2_H264_PPS_FLAG_ENTROPY_CODING_MODE				0x0001
 #define V4L2_H264_PPS_FLAG_BOTTOM_FIELD_PIC_ORDER_IN_FRAME_PRESENT	0x0002
@@ -101,31 +81,7 @@ struct v4l2_ctrl_h264_sps {
 #define V4L2_H264_PPS_FLAG_TRANSFORM_8X8_MODE				0x0040
 #define V4L2_H264_PPS_FLAG_SCALING_MATRIX_PRESENT			0x0080
 
-struct v4l2_ctrl_h264_pps {
-	__u8 pic_parameter_set_id;
-	__u8 seq_parameter_set_id;
-	__u8 num_slice_groups_minus1;
-	__u8 num_ref_idx_l0_default_active_minus1;
-	__u8 num_ref_idx_l1_default_active_minus1;
-	__u8 weighted_bipred_idc;
-	__s8 pic_init_qp_minus26;
-	__s8 pic_init_qs_minus26;
-	__s8 chroma_qp_index_offset;
-	__s8 second_chroma_qp_index_offset;
-	__u16 flags;
-};
 
-struct v4l2_ctrl_h264_scaling_matrix {
-	__u8 scaling_list_4x4[6][16];
-	__u8 scaling_list_8x8[6][64];
-};
-
-struct v4l2_h264_weight_factors {
-	__s16 luma_weight[32];
-	__s16 luma_offset[32];
-	__s16 chroma_weight[32][2];
-	__s16 chroma_offset[32][2];
-};
 
 #define V4L2_H264_CTRL_PRED_WEIGHTS_REQUIRED(pps, slice) \
 	((((pps)->flags & V4L2_H264_PPS_FLAG_WEIGHTED_PRED) && \
@@ -134,11 +90,6 @@ struct v4l2_h264_weight_factors {
 	 ((pps)->weighted_bipred_idc == 1 && \
 	  (slice)->slice_type == V4L2_H264_SLICE_TYPE_B))
 
-struct v4l2_ctrl_h264_pred_weights {
-	__u16 luma_log2_weight_denom;
-	__u16 chroma_log2_weight_denom;
-	struct v4l2_h264_weight_factors weight_factors[2];
-};
 
 #define V4L2_H264_SLICE_TYPE_P				0
 #define V4L2_H264_SLICE_TYPE_B				1
@@ -153,79 +104,17 @@ struct v4l2_ctrl_h264_pred_weights {
 #define V4L2_H264_BOTTOM_FIELD_REF			0x2
 #define V4L2_H264_FRAME_REF				0x3
 
-struct v4l2_h264_reference {
-	__u8 fields;
 
-	/* Index into v4l2_ctrl_h264_decode_params.dpb[] */
-	__u8 index;
-};
-
-struct v4l2_ctrl_h264_slice_params {
-	/* Offset in bits to slice_data() from the beginning of this slice. */
-	__u32 header_bit_size;
-
-	__u32 first_mb_in_slice;
-
-	__u8 slice_type;
-	__u8 colour_plane_id;
-	__u8 redundant_pic_cnt;
-	__u8 cabac_init_idc;
-	__s8 slice_qp_delta;
-	__s8 slice_qs_delta;
-	__u8 disable_deblocking_filter_idc;
-	__s8 slice_alpha_c0_offset_div2;
-	__s8 slice_beta_offset_div2;
-	__u8 num_ref_idx_l0_active_minus1;
-	__u8 num_ref_idx_l1_active_minus1;
-
-	__u8 reserved;
-
-	struct v4l2_h264_reference ref_pic_list0[V4L2_H264_REF_LIST_LEN];
-	struct v4l2_h264_reference ref_pic_list1[V4L2_H264_REF_LIST_LEN];
-
-	__u32 flags;
-};
 
 #define V4L2_H264_DPB_ENTRY_FLAG_VALID		0x01
 #define V4L2_H264_DPB_ENTRY_FLAG_ACTIVE		0x02
 #define V4L2_H264_DPB_ENTRY_FLAG_LONG_TERM	0x04
 #define V4L2_H264_DPB_ENTRY_FLAG_FIELD		0x08
 
-struct v4l2_h264_dpb_entry {
-	__u64 reference_ts;
-	__u32 pic_num;
-	__u16 frame_num;
-	__u8 fields;
-	__u8 reserved[5];
-	/* Note that field is indicated by v4l2_buffer.field */
-	__s32 top_field_order_cnt;
-	__s32 bottom_field_order_cnt;
-	__u32 flags; /* V4L2_H264_DPB_ENTRY_FLAG_* */
-};
 
 #define V4L2_H264_DECODE_PARAM_FLAG_IDR_PIC		0x01
 #define V4L2_H264_DECODE_PARAM_FLAG_FIELD_PIC		0x02
 #define V4L2_H264_DECODE_PARAM_FLAG_BOTTOM_FIELD	0x04
 
-struct v4l2_ctrl_h264_decode_params {
-	struct v4l2_h264_dpb_entry dpb[V4L2_H264_NUM_DPB_ENTRIES];
-	__u16 nal_ref_idc;
-	__u16 frame_num;
-	__s32 top_field_order_cnt;
-	__s32 bottom_field_order_cnt;
-	__u16 idr_pic_id;
-	__u16 pic_order_cnt_lsb;
-	__s32 delta_pic_order_cnt_bottom;
-	__s32 delta_pic_order_cnt0;
-	__s32 delta_pic_order_cnt1;
-	/* Size in bits of dec_ref_pic_marking() syntax element. */
-	__u32 dec_ref_pic_marking_bit_size;
-	/* Size in bits of pic order count syntax. */
-	__u32 pic_order_cnt_bit_size;
-	__u32 slice_group_change_cycle;
-
-	__u32 reserved;
-	__u32 flags; /* V4L2_H264_DECODE_PARAM_FLAG_* */
-};
 
 #endif


### PR DESCRIPTION
removed some redefined structs from h264-ctrls.h since they are defined exactly equal in videodev2.h and v4l2-controls.h kernel headers